### PR TITLE
Add law memory system core modules

### DIFF
--- a/apps/law_memory/__init__.py
+++ b/apps/law_memory/__init__.py
@@ -1,0 +1,15 @@
+"""Law memory system core package.
+
+This package implements the recursive law feedback architecture (RLFA) used
+throughout the project.  The modules provide numerical solvers, CLI tools,
+training utilities and supporting analytics used by the gyroscopic
+stabilisation stack.
+"""
+
+from .core import LawMemoryConfig, LawMemorySimulator, LawMemoryState
+
+__all__ = [
+    "LawMemoryConfig",
+    "LawMemorySimulator",
+    "LawMemoryState",
+]

--- a/apps/law_memory/chaos.py
+++ b/apps/law_memory/chaos.py
@@ -1,0 +1,19 @@
+"""Chaos and torsion diagnostics for law memory simulations."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def compute_torsion_spectrum(gamma: np.ndarray) -> np.ndarray:
+    """Return a simple frequency spectrum that acts as a chaos proxy."""
+
+    if gamma.ndim != 1:
+        raise ValueError("gamma must be one dimensional")
+    delta = np.gradient(gamma)
+    torsion_like = np.abs(np.sin(delta))
+    fft = np.fft.rfft(torsion_like)
+    return np.abs(fft)
+
+
+__all__ = ["compute_torsion_spectrum"]

--- a/apps/law_memory/core.py
+++ b/apps/law_memory/core.py
@@ -1,0 +1,193 @@
+"""Numerical infrastructure for the recursive law feedback architecture.
+
+The :mod:`apps.law_memory.core` module contains a light‑weight PDE solver used
+throughout the project.  The solver intentionally avoids heavy dependencies so
+that unit tests remain inexpensive while still exposing the physics inspired
+interfaces described in the system specification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional
+
+import numpy as np
+
+ArrayLike = Iterable[float]
+
+
+@dataclass
+class LawMemoryConfig:
+    """Configuration container for the :class:`LawMemorySimulator`.
+
+    Parameters mirror the notation used in the design notes.  The defaults are
+    chosen such that the solver produces smooth trajectories on relatively
+    coarse grids and with small time steps, making it suitable for unit tests
+    and documentation examples.
+    """
+
+    grid_points: int = 128
+    length: float = 20.0
+    dt: float = 0.05
+    t_final: float = 10.0
+    alpha1: float = 1.0
+    alpha2: float = 0.5
+    beta: float = 0.1
+    lambda_: float = 0.8
+    eta: float = 0.5
+    memory_tau: float = 5.0
+    memory_omega: float = 2.0
+    phi0: float = np.pi / 4
+    delta_phi: float = 0.1
+
+    def __post_init__(self) -> None:
+        if self.grid_points < 8:
+            raise ValueError("grid_points must be >= 8")
+        if self.length <= 0:
+            raise ValueError("length must be positive")
+        if self.dt <= 0 or self.t_final <= 0:
+            raise ValueError("time parameters must be positive")
+        if self.memory_tau <= 0:
+            raise ValueError("memory_tau must be positive")
+
+
+@dataclass
+class LawMemoryState:
+    """Container returned by :class:`LawMemorySimulator`.
+
+    The object stores the spatial grid, the time stamps and the computed law
+    field evolution.  Convenience properties expose derived diagnostics that
+    are reused across multiple modules.
+    """
+
+    x: np.ndarray
+    t: np.ndarray
+    law_field: np.ndarray
+    gamma: np.ndarray
+    chi: np.ndarray
+    torsion: np.ndarray
+    memory_loop: np.ndarray
+
+    @property
+    def final_profile(self) -> np.ndarray:
+        """Return the final law field profile."""
+
+        return self.law_field[-1]
+
+    @property
+    def loop_entropy(self) -> float:
+        """Return a scalar loop entropy diagnostic used in tests."""
+
+        centred = self.law_field - self.law_field.mean(axis=1, keepdims=True)
+        return float(np.mean(np.var(centred, axis=1)))
+
+
+class LawMemorySimulator:
+    """Implements a one-dimensional explicit solver for law memory evolution."""
+
+    def __init__(self, config: Optional[LawMemoryConfig] = None) -> None:
+        self.config = config or LawMemoryConfig()
+
+        self._x = np.linspace(
+            -self.config.length / 2.0,
+            self.config.length / 2.0,
+            self.config.grid_points,
+        )
+        self._dx = self._x[1] - self._x[0]
+        steps = int(round(self.config.t_final / self.config.dt))
+        self._t = np.linspace(0.0, self.config.t_final, steps + 1)
+
+    @property
+    def grid(self) -> np.ndarray:
+        return self._x
+
+    @property
+    def time(self) -> np.ndarray:
+        return self._t
+
+    def _coerce_profile(
+        self,
+        value: Optional[Callable[[np.ndarray], np.ndarray] | ArrayLike],
+        default: Callable[[np.ndarray], np.ndarray],
+    ) -> np.ndarray:
+        if value is None:
+            return default(self._x)
+        if callable(value):
+            data = np.asarray(value(self._x), dtype=float)
+        else:
+            arr = np.asarray(list(value), dtype=float)
+            if arr.size != self._x.size:
+                raise ValueError("profile has incorrect size")
+            data = arr
+        return data
+
+    def simulate(
+        self,
+        gamma_profile: Optional[Callable[[np.ndarray], np.ndarray] | ArrayLike] = None,
+        chi_profile: Optional[Callable[[np.ndarray], np.ndarray] | ArrayLike] = None,
+        torsion_profile: Optional[Callable[[np.ndarray], np.ndarray] | ArrayLike] = None,
+        memory_loop: Optional[Callable[[np.ndarray], np.ndarray] | ArrayLike] = None,
+        initial_field: Optional[ArrayLike] = None,
+    ) -> LawMemoryState:
+        """Evolve the law field using the recursive feedback equation."""
+
+        gamma = self._coerce_profile(gamma_profile, lambda x: np.exp(-(x**2) / 10))
+        chi = self._coerce_profile(
+            chi_profile,
+            lambda x: (2 * np.pi * np.sin(x / 2.0)) ** 2 * np.exp(-(x**2) / 10),
+        )
+        torsion = self._coerce_profile(
+            torsion_profile,
+            lambda x: np.gradient(np.sin(x), self._dx, edge_order=2),
+        )
+        hyst = self._coerce_profile(memory_loop, lambda x: 0.2 * np.exp(-(x**2) / 5.0))
+
+        if initial_field is None:
+            law = np.exp(-(self._x**2) / 4.0)
+        else:
+            law = np.asarray(list(initial_field), dtype=float)
+            if law.size != self._x.size:
+                raise ValueError("initial_field has incorrect size")
+
+        law_evolution = np.empty((self._t.size, self._x.size), dtype=float)
+        law_evolution[0] = law
+
+        phi = self.config.phi0 + self.config.delta_phi * np.tanh(self._x)
+        feedback_state = np.zeros_like(self._x)
+        decay = np.exp(-self.config.dt / self.config.memory_tau)
+
+        for i in range(1, self._t.size):
+            grad_chi = np.gradient(chi, self._dx, edge_order=2)
+            divergence = np.gradient(gamma * grad_chi, self._dx, edge_order=2)
+            torsion_div = np.gradient(torsion, self._dx, edge_order=2)
+            phase_term = -self.config.beta * np.gradient(phi * law, self._dx, edge_order=2)
+            memory_term = self.config.lambda_ * hyst
+
+            feedback_state = (
+                decay * feedback_state
+                + (1.0 - decay) * self.config.eta * divergence
+            )
+
+            rhs = (
+                self.config.alpha1 * divergence
+                + self.config.alpha2 * torsion_div
+                + phase_term
+                + memory_term
+                + feedback_state
+            )
+
+            law = law + self.config.dt * rhs
+            law_evolution[i] = law
+
+        return LawMemoryState(
+            x=self._x.copy(),
+            t=self._t.copy(),
+            law_field=law_evolution,
+            gamma=gamma,
+            chi=chi,
+            torsion=torsion,
+            memory_loop=hyst,
+        )
+
+
+__all__ = ["LawMemoryConfig", "LawMemorySimulator", "LawMemoryState"]

--- a/apps/law_memory/dual_flip.py
+++ b/apps/law_memory/dual_flip.py
@@ -1,0 +1,32 @@
+"""PT-dual manipulation utilities for the law memory field."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def reverse_pt_dual(law_stack: np.ndarray, phi_shift: float = 0.0) -> np.ndarray:
+    """Return a PT-dual reversed copy of ``law_stack``."""
+
+    if law_stack.ndim != 2:
+        raise ValueError("law_stack must be 2D")
+    reversed_stack = law_stack[::-1].copy()
+    width = reversed_stack.shape[1]
+    shift = int(round(phi_shift * width / (2 * np.pi)))
+    if shift:
+        reversed_stack = np.roll(reversed_stack, shift=shift, axis=1)
+    return reversed_stack
+
+
+def compute_loop_entropy(forward: np.ndarray, reverse: np.ndarray) -> tuple[np.ndarray, float]:
+    """Return the point-wise and mean entropy difference between two stacks."""
+
+    if forward.shape != reverse.shape:
+        raise ValueError("stack dimensions must match")
+    forward_c = forward - forward.mean(axis=1, keepdims=True)
+    reverse_c = reverse - reverse.mean(axis=1, keepdims=True)
+    diff = np.abs(np.var(forward_c, axis=0) - np.var(reverse_c, axis=0))
+    return diff, float(np.mean(diff))
+
+
+__all__ = ["reverse_pt_dual", "compute_loop_entropy"]

--- a/apps/law_memory/metrics.py
+++ b/apps/law_memory/metrics.py
@@ -1,0 +1,26 @@
+"""Metric coupling helpers for law memory feedback."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+
+def inject_into_metrics(r: np.ndarray, law: np.ndarray, xi: float = 0.382, lambda_h: float = 0.1457) -> Dict[str, float]:
+    """Return updated metric coefficients from a law profile."""
+
+    if r.size != law.size:
+        raise ValueError("grid mismatch")
+    r_safe = np.where(r == 0, 1e-6, r)
+    phi = xi * law / (r_safe**2)
+    gamma = 1.0 + lambda_h * law
+    return {
+        "phi_mean": float(np.mean(phi)),
+        "phi_std": float(np.std(phi)),
+        "gamma_mean": float(np.mean(gamma)),
+        "gamma_std": float(np.std(gamma)),
+    }
+
+
+__all__ = ["inject_into_metrics"]

--- a/apps/law_memory/module.py
+++ b/apps/law_memory/module.py
@@ -1,0 +1,72 @@
+"""Functional helpers that expose the law evolution equation.
+
+This module acts as a convenience wrapper around :mod:`apps.law_memory.core`
+so that existing scripts can work with a functional programming interface.  The
+helpers are thin layers that simply delegate to :class:`LawMemorySimulator` and
+add a few diagnostics used throughout the project.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import numpy as np
+
+from .core import LawMemoryConfig, LawMemorySimulator
+
+
+def law_rhs(
+    x: np.ndarray,
+    law: np.ndarray,
+    gamma: np.ndarray,
+    chi: np.ndarray,
+    torsion: np.ndarray,
+    phi: np.ndarray,
+    config: Optional[LawMemoryConfig] = None,
+) -> np.ndarray:
+    """Return the right hand side of the law evolution equation.
+
+    Parameters
+    ----------
+    x:
+        Spatial coordinates.
+    law:
+        Current law field profile.
+    gamma, chi, torsion, phi:
+        Auxiliary profiles as defined in the design notes.
+    config:
+        Optional :class:`LawMemoryConfig`.  When omitted the default
+        configuration is used.
+    """
+
+    cfg = config or LawMemoryConfig(grid_points=len(x), length=x.ptp())
+    dx = x[1] - x[0]
+    grad_chi = np.gradient(chi, dx, edge_order=2)
+    divergence = np.gradient(gamma * grad_chi, dx, edge_order=2)
+    torsion_div = np.gradient(torsion, dx, edge_order=2)
+    phase_term = -cfg.beta * np.gradient(phi * law, dx, edge_order=2)
+    return cfg.alpha1 * divergence + cfg.alpha2 * torsion_div + phase_term
+
+
+def integrate_law(
+    config: Optional[LawMemoryConfig] = None,
+    **profiles: Callable[[np.ndarray], np.ndarray],
+) -> LawMemorySimulator:
+    """Integrate the law equation using ``profiles`` as inputs.
+
+    The function returns the :class:`LawMemorySimulator` instance so callers can
+    reuse the computed state for further diagnostics.
+    """
+
+    sim = LawMemorySimulator(config=config)
+    sim.simulate(
+        gamma_profile=profiles.get("gamma_profile"),
+        chi_profile=profiles.get("chi_profile"),
+        torsion_profile=profiles.get("torsion_profile"),
+        memory_loop=profiles.get("memory_loop"),
+        initial_field=profiles.get("initial_field"),
+    )
+    return sim
+
+
+__all__ = ["law_rhs", "integrate_law"]

--- a/apps/law_memory/neuro_semantic.py
+++ b/apps/law_memory/neuro_semantic.py
@@ -1,0 +1,38 @@
+"""Neuro semantic coupling utilities for the law memory system."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def compute_chi_int(psi: np.ndarray, epsilon: float = 1e-9) -> np.ndarray:
+    """Return the χ-int field derived from ``psi``."""
+
+    phase = np.angle(psi)
+    gradients = np.gradient(phase)
+    norm_sq = np.zeros_like(phase, dtype=float)
+    for grad in gradients:
+        norm_sq += grad**2
+    return norm_sq + epsilon
+
+
+def inject_chi_int_coupling(law: np.ndarray, chi_int: np.ndarray, epsilon: float = 1e-5) -> np.ndarray:
+    """Scale ``law`` using the χ-int feedback field."""
+
+    if law.shape != chi_int.shape:
+        raise ValueError("shape mismatch between law and χ-int")
+    mean = np.mean(chi_int)
+    scaling = 1.0 + chi_int / (mean + epsilon)
+    return law * scaling
+
+
+def generate_mock_psi(shape: tuple[int, ...], seed: int = 42) -> np.ndarray:
+    """Generate a reproducible mock semantic wavefunction."""
+
+    rng = np.random.default_rng(seed)
+    magnitude = 1.0 + 0.05 * rng.standard_normal(shape)
+    phase = 2 * np.pi * rng.random(shape)
+    return magnitude * np.exp(1j * phase)
+
+
+__all__ = ["compute_chi_int", "inject_chi_int_coupling", "generate_mock_psi"]

--- a/apps/law_memory/observables.py
+++ b/apps/law_memory/observables.py
@@ -1,0 +1,18 @@
+"""Utilities for converting BEC observables into semantic fields."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def density_to_gamma(density: np.ndarray) -> np.ndarray:
+    """Convert a condensate density array into the γ coherence field."""
+
+    density = np.asarray(density, dtype=float)
+    max_val = np.max(density)
+    if max_val == 0:
+        return np.zeros_like(density)
+    return density / max_val
+
+
+__all__ = ["density_to_gamma"]

--- a/apps/law_memory/pipeline.py
+++ b/apps/law_memory/pipeline.py
@@ -1,0 +1,98 @@
+"""Command line pipeline for the law memory system.
+
+The CLI orchestrates the different stages described in the architecture
+overview: observable conversion, PDE evolution, diagnostics and visualisation.
+Each stage uses the light‑weight implementations contained in this package so
+that the command can be executed inside unit tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, Tuple
+
+import numpy as np
+
+from .core import LawMemoryConfig, LawMemorySimulator
+from .visual.diagnostics import plot_entropy_loop, plot_law_attractor
+from .chaos import compute_torsion_spectrum
+from .metrics import inject_into_metrics
+from .observables import density_to_gamma
+
+
+def _load_density(path: Path) -> np.ndarray:
+    data = np.load(path)
+    if data.ndim == 1:
+        return data[np.newaxis, :]
+    if data.ndim != 2:
+        raise ValueError("density input must be 1D or 2D")
+    return data
+
+
+def _evolve_law(density: np.ndarray, cfg: LawMemoryConfig) -> Tuple[np.ndarray, LawMemorySimulator]:
+    gamma = density_to_gamma(density)
+    chi = gamma**2
+    sim = LawMemorySimulator(config=cfg)
+    state = sim.simulate(gamma_profile=lambda _: np.mean(gamma, axis=0), chi_profile=lambda _: np.mean(chi, axis=0))
+    return state.law_field, sim
+
+
+def _save_checkpoint(path: Path, law_field: np.ndarray, cfg: LawMemoryConfig) -> None:
+    payload: Dict[str, object] = {
+        "config": asdict(cfg),
+        "law_field": law_field.tolist(),
+    }
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Law memory processing pipeline")
+    parser.add_argument("density", type=Path, help="Path to numpy array with condensate density")
+    parser.add_argument("--output-dir", type=Path, default=Path("chk"))
+    parser.add_argument("--config", type=Path, help="Optional JSON configuration override")
+    parser.add_argument("--make-plots", action="store_true")
+    return parser
+
+
+def _load_config(path: Path | None) -> LawMemoryConfig:
+    if path is None:
+        return LawMemoryConfig()
+    cfg_data = json.loads(path.read_text())
+    return LawMemoryConfig(**cfg_data)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    cfg = _load_config(args.config)
+    density = _load_density(args.density)
+    law_field, sim = _evolve_law(density, cfg)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint = args.output_dir / "law_memory_checkpoint.json"
+    _save_checkpoint(checkpoint, law_field, cfg)
+
+    gamma = sim.simulate().gamma  # Use default state for diagnostics
+    torsion_spectrum = compute_torsion_spectrum(gamma)
+    metrics = inject_into_metrics(sim.grid, law_field[-1])
+
+    diagnostics_path = args.output_dir / "diagnostics.json"
+    diagnostics_path.write_text(
+        json.dumps({"torsion_spectrum": torsion_spectrum.tolist(), "metrics": metrics}, indent=2)
+    )
+
+    if args.make_plots:
+        plot_dir = args.output_dir / "plots"
+        plot_dir.mkdir(exist_ok=True, parents=True)
+        plot_entropy_loop(law_field, gamma, plot_dir / "entropy_loop.png")
+        plot_law_attractor(law_field, plot_dir / "attractor.png")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/law_memory/recursive.py
+++ b/apps/law_memory/recursive.py
@@ -1,0 +1,51 @@
+"""Recursive feedback driver with optional MPI acceleration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - MPI is optional
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade
+    MPI = None
+
+from .core import LawMemoryConfig, LawMemorySimulator
+
+
+@dataclass
+class ParameterSet:
+    gamma0: float
+    chi0: float
+    delta: float
+
+
+def _simulate_for_params(params: ParameterSet, config: LawMemoryConfig) -> np.ndarray:
+    sim = LawMemorySimulator(config=config)
+    gamma_profile = lambda x: params.gamma0 * np.exp(-(x**2) / 10)
+    chi_profile = lambda x: params.chi0 * np.exp(-(x**2) / 9)
+    state = sim.simulate(gamma_profile=gamma_profile, chi_profile=chi_profile)
+    return state.law_field
+
+
+def run_recursive_ensemble(parameters: Sequence[ParameterSet], config: LawMemoryConfig | None = None) -> List[np.ndarray]:
+    cfg = config or LawMemoryConfig()
+    if MPI is None or (comm := MPI.COMM_WORLD).size == 1:  # type: ignore[truthy-function]
+        return [_simulate_for_params(p, cfg) for p in parameters]
+
+    comm = MPI.COMM_WORLD  # type: ignore[assignment]
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+    chunks = [parameters[i::size] for i in range(size)]
+    local_params = chunks[rank]
+    local_results = [_simulate_for_params(p, cfg) for p in local_params]
+    gathered = comm.allgather(local_results)
+    results: List[np.ndarray] = []
+    for chunk in gathered:
+        results.extend(chunk)
+    return results
+
+
+__all__ = ["ParameterSet", "run_recursive_ensemble"]

--- a/apps/law_memory/temporal_echo.py
+++ b/apps/law_memory/temporal_echo.py
@@ -1,0 +1,21 @@
+"""Temporal echo injection helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def inject_temporal_echo(law_stack: np.ndarray, delay: int = 10, decay: float = 0.97) -> np.ndarray:
+    """Compute the temporal echo field from a sequence of law states."""
+
+    if law_stack.ndim != 2:
+        raise ValueError("law_stack must be 2D")
+    steps = law_stack.shape[0]
+    echo = np.zeros_like(law_stack[0])
+    depth = min(delay, steps)
+    for lag in range(1, depth):
+        echo += (decay**lag) * law_stack[-lag]
+    return echo
+
+
+__all__ = ["inject_temporal_echo"]

--- a/apps/law_memory/tests/conftest.py
+++ b/apps/law_memory/tests/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ..core import LawMemorySimulator
+
+
+@pytest.fixture(scope="module")
+def law_stack() -> np.ndarray:
+    sim = LawMemorySimulator()
+    state = sim.simulate()
+    return state.law_field
+
+
+@pytest.fixture(scope="module")
+def psi_field(law_stack: np.ndarray) -> np.ndarray:
+    rng = np.random.default_rng(123)
+    phase = rng.uniform(0, 2 * np.pi, size=law_stack.shape)
+    return np.exp(1j * phase)

--- a/apps/law_memory/tests/test_chi_injection.py
+++ b/apps/law_memory/tests/test_chi_injection.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ..neuro_semantic import compute_chi_int, inject_chi_int_coupling
+
+
+def test_chi_feedback_modulates_field(law_stack: np.ndarray, psi_field: np.ndarray) -> None:
+    chi = compute_chi_int(psi_field)
+    law_slice = law_stack[0]
+    chi_slice = chi[0]
+    modulated = inject_chi_int_coupling(law_slice, chi_slice)
+    assert modulated.shape == law_slice.shape
+    assert np.max(np.abs(modulated - law_slice)) > 0
+    assert np.mean(np.abs(modulated - law_slice)) < 0.5

--- a/apps/law_memory/tests/test_dual_entropy.py
+++ b/apps/law_memory/tests/test_dual_entropy.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ..dual_flip import compute_loop_entropy, reverse_pt_dual
+
+
+def test_entropy_symmetry(law_stack: np.ndarray) -> None:
+    dual = reverse_pt_dual(law_stack)
+    diff, mean = compute_loop_entropy(law_stack, dual)
+    assert diff.shape == law_stack.shape[1:]
+    assert mean < 1e-2
+
+
+def test_reverse_is_time_ordered(law_stack: np.ndarray) -> None:
+    dual = reverse_pt_dual(law_stack)
+    np.testing.assert_allclose(dual[0], law_stack[-1])

--- a/apps/law_memory/training_extension.py
+++ b/apps/law_memory/training_extension.py
@@ -1,0 +1,125 @@
+"""Advanced operator training helpers for GPT aligned control."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import yaml
+
+from .training_suite import LawManifoldEncoder
+
+
+@dataclass
+class OperatorBasis:
+    """Light weight PCA-like container."""
+
+    mean: np.ndarray
+    components: np.ndarray
+
+
+class LawOperatorTrainer:
+    """Analyse and mutate law operator trajectories."""
+
+    def __init__(self, law_tensor: np.ndarray, n_components: int = 5) -> None:
+        if law_tensor.ndim != 2:
+            raise ValueError("law_tensor must be (time, space)")
+        self.law_tensor = np.asarray(law_tensor, dtype=float)
+        self.n_components = n_components
+        self.operators: np.ndarray | None = None
+        self.basis: OperatorBasis | None = None
+        self.reduce()
+
+    def clone(self) -> "LawOperatorTrainer":
+        clone = LawOperatorTrainer(self.law_tensor.copy(), self.n_components)
+        clone.operators = None if self.operators is None else self.operators.copy()
+        clone.basis = None if self.basis is None else OperatorBasis(
+            self.basis.mean.copy(), self.basis.components.copy()
+        )
+        return clone
+
+    def reduce(self) -> np.ndarray:
+        mean = self.law_tensor.mean(axis=0)
+        centred = self.law_tensor - mean
+        u, s, vt = np.linalg.svd(centred, full_matrices=False)
+        components = vt[: self.n_components]
+        operators = u[:, : self.n_components] * s[: self.n_components]
+        self.basis = OperatorBasis(mean=mean, components=components)
+        self.operators = operators
+        return operators
+
+    def reconstruct(self) -> np.ndarray:
+        if self.basis is None or self.operators is None:
+            raise RuntimeError("basis not computed")
+        reconstruction = self.operators @ self.basis.components
+        return reconstruction + self.basis.mean
+
+    def add_semantic_projection_layer(self, j_mu: np.ndarray, coupling_weight: float = 0.618) -> np.ndarray:
+        if j_mu.shape != self.law_tensor.shape:
+            raise ValueError("j_mu shape mismatch")
+        norm = np.linalg.norm(j_mu, axis=0)
+        self.law_tensor = self.law_tensor * (1 + coupling_weight * norm)
+        return self.reduce()
+
+    def plot_operator_drift(self, path: Path) -> None:
+        if self.operators is None:
+            raise RuntimeError("operators not available")
+        plt.figure(figsize=(7, 4))
+        for idx in range(self.operators.shape[1]):
+            plt.plot(self.operators[:, idx], label=f"𝒪{idx}")
+        plt.xlabel("Time index")
+        plt.ylabel("Operator value")
+        plt.title("Operator drift")
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(path)
+        plt.close()
+
+    def attach_gpt_guidance(self, suggestion_file: Path, influence_strength: float = 0.25) -> np.ndarray:
+        if self.operators is None:
+            raise RuntimeError("operators not available")
+        cfg = yaml.safe_load(Path(suggestion_file).read_text())
+        mutate = cfg.get("mutate", {})
+        weights = mutate.get("operator_weights", [0.0] * self.operators.shape[1])
+        if len(weights) != self.operators.shape[1]:
+            raise ValueError("operator_weights size mismatch")
+        bias = np.asarray(weights) * influence_strength
+        self.operators = self.operators + bias[np.newaxis, :]
+        if mutate.get("shift_basis", False):
+            self.reduce()
+        if mutate.get("reproject_after", True):
+            self.law_tensor = self.reconstruct()
+        return self.operators
+
+    def generate_token_batch(self, prompts_yaml: Path, output_dir: Path) -> List[Path]:
+        specs = yaml.safe_load(Path(prompts_yaml).read_text())
+        output_dir.mkdir(parents=True, exist_ok=True)
+        generated: List[Path] = []
+        for idx, spec in enumerate(specs):
+            name = spec.get("name", f"token_stream_{idx}")
+            suggestion_path = output_dir / f"{name.replace(' ', '_')}.yaml"
+            suggestion_path.write_text(yaml.dump(spec))
+
+            clone = self.clone()
+            clone.attach_gpt_guidance(suggestion_path)
+            encoder = LawManifoldEncoder(clone.law_tensor)
+            token = encoder.encode()
+            token_path = output_dir / f"law_tokens_{idx}.json"
+            token_path.write_text(json.dumps(token.to_dict(), indent=2))
+            generated.append(token_path)
+        return generated
+
+    def export_tokens(self, path: Path) -> None:
+        encoder = LawManifoldEncoder(self.law_tensor)
+        token = encoder.encode()
+        path.write_text(json.dumps(token.to_dict(), indent=2))
+
+
+__all__ = ["LawOperatorTrainer"]

--- a/apps/law_memory/training_suite.py
+++ b/apps/law_memory/training_suite.py
@@ -1,0 +1,63 @@
+"""Closed loop training utilities for the law memory system."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+
+@dataclass
+class LawTokenVector:
+    """Container for GPT compatible law tokens."""
+
+    gamma_level: float
+    torsion_noise: float
+    hysteresis_depth: float
+    coherence_mode: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "LAW_GAMMA_LEVEL": round(self.gamma_level, 3),
+            "LAW_TORSION_NOISE": round(self.torsion_noise, 4),
+            "LAW_HYSTERESIS_DEPTH": round(self.hysteresis_depth, 4),
+            "LAW_COHERENCE_MODE": self.coherence_mode,
+        }
+
+
+class LawManifoldEncoder:
+    """Distil law manifold tensors into GPT compatible embeddings."""
+
+    def __init__(self, law_tensor: np.ndarray) -> None:
+        if law_tensor.ndim != 2:
+            raise ValueError("law_tensor must be (time, space)")
+        self.law_tensor = law_tensor
+
+    def encode(self) -> LawTokenVector:
+        gamma_level = float(np.mean(self.law_tensor))
+        torsion_noise = float(np.std(np.gradient(self.law_tensor, axis=1)))
+        hysteresis_depth = float(np.mean(np.abs(self.law_tensor - self.law_tensor[::-1])))
+        coherence_mode = "stable" if torsion_noise < 0.4 else "chaotic"
+        return LawTokenVector(gamma_level, torsion_noise, hysteresis_depth, coherence_mode)
+
+
+def save_tokens(token: LawTokenVector, path: Path) -> None:
+    path.write_text(json.dumps({"law_tokens": token.to_dict()}, indent=2))
+
+
+def inject_tokens(token: LawTokenVector, template: str) -> str:
+    block = "\n".join(
+        f"{key}: {value}" for key, value in token.to_dict().items()
+    )
+    return f"-- RCC LAW CONFIG --\n{block}\n\n{template}"
+
+
+__all__ = [
+    "LawTokenVector",
+    "LawManifoldEncoder",
+    "save_tokens",
+    "inject_tokens",
+]

--- a/apps/law_memory/visual/diagnostics.py
+++ b/apps/law_memory/visual/diagnostics.py
@@ -1,0 +1,49 @@
+"""Diagnostic plots used across the law memory system."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_entropy_loop(law_field: np.ndarray, gamma: np.ndarray, output: Path) -> None:
+    """Plot the mean entropy difference between forward and reverse loops."""
+
+    forward = law_field
+    reverse = forward[::-1]
+    entropy = np.abs(forward - reverse).mean(axis=0)
+    plt.figure(figsize=(6, 4))
+    plt.plot(entropy, label="|Δℒ|")
+    plt.plot(gamma, label="γ", alpha=0.7)
+    plt.xlabel("Grid index")
+    plt.ylabel("Amplitude")
+    plt.title("Entropy loop diagnostic")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output)
+    plt.close()
+
+
+def plot_law_attractor(law_field: np.ndarray, output: Path) -> None:
+    """Visualise the attractor landscape by averaging over time."""
+
+    attractor = law_field.mean(axis=0)
+    plt.figure(figsize=(6, 4))
+    plt.imshow(law_field, aspect="auto", cmap="plasma")
+    plt.colorbar(label="ℒ")
+    plt.plot(attractor, color="white", linewidth=1.0)
+    plt.title("Law attractor evolution")
+    plt.xlabel("Space index")
+    plt.ylabel("Time index")
+    plt.tight_layout()
+    plt.savefig(output)
+    plt.close()
+
+
+__all__ = ["plot_entropy_loop", "plot_law_attractor"]


### PR DESCRIPTION
## Summary
- add a law memory core simulator and helper APIs that implement the recursive law feedback equation
- introduce CLI, diagnostics, temporal echo, neuro-semantic coupling and operator training utilities for law evolution workflows
- provide pytest-based validation for PT-dual entropy symmetry and chi-int feedback modulation

## Testing
- `pytest apps/law_memory/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68e703447774832caa1e2bea53885959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a configurable Law Memory simulator with functional helpers and a public package entrypoint.
  - Added diagnostics: torsion spectrum, density-to-gamma, metrics injection, neuro-semantic χ-int coupling, temporal echo, PT-dual reversal and loop entropy.
  - Added recursive ensemble runner with optional MPI.
  - Added training tools: manifold encoder and tokens, operator trainer with projection, guidance, and batch token generation.
  - Added visualizations for entropy loop and law attractor.
  - Added a CLI pipeline to run simulations, save checkpoints/diagnostics, and optionally generate plots.
- Tests
  - Added tests for dual entropy symmetry and χ-int coupling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->