### PR TITLE
Add law operator trainer utilities and CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Law Operator CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run tox
+        run: tox

--- a/configs/law_training/suggestion_hybrid_echo_cycle_entropy.yaml
+++ b/configs/law_training/suggestion_hybrid_echo_cycle_entropy.yaml
@@ -1,0 +1,42 @@
+metadata:
+  version: 2.0
+  description: Cyclic entropy modulation for recursive law hysteresis encoding
+
+global_settings:
+  mutation_temperature: 0.38
+  memory_loop_feedback: enabled
+  cycle_entropy_cap: 0.15
+  seed: 42024
+
+operator_projection_targets:
+  - name: entropy-cycled-loop
+    type: χ-gradient field
+    evolution_form: "∂χ/∂t = α sin(ω t)"
+    ω: 0.897597901
+    α: 0.12
+
+  - name: loop_persistence
+    constraint: "∇Φ ∝ ∇χ"
+    feedback_strength: 0.6
+    hysteresis_goal: maintain ±0.25
+
+operator_mutation_rules:
+  - name: spiral_echo_bleed
+    function: "Ψ → Ψ + ε ∂γ/∂t"
+    ε: 0.01
+    triggers: law basin crossing
+
+  - name: decoherence_recoil
+    form: "γ(t) ↔ γ(t-Δt) ± κ sin(χ)"
+    κ: 0.05
+    decay_envelope: tanh
+
+fitness_evaluation:
+  memory_loop_closure: "> 0.94"
+  entropy_variance_per_cycle: '< 0.04'
+  attractor_centroid_shift: bounded
+
+mutate:
+  operator_weights: [0.11, -0.06, 0.09, -0.02, 0.03]
+  shift_basis: true
+  reproject_after: true

--- a/configs/law_training/suggestion_hybrid_gpt_chaos_sieve.yaml
+++ b/configs/law_training/suggestion_hybrid_gpt_chaos_sieve.yaml
@@ -1,0 +1,36 @@
+metadata:
+  version: 2.2
+  description: Chaos sieve with GPT-aligned law pruning under entropy shock
+
+global_settings:
+  chaos_pressure: elevated
+  semantic_memory_retention: '> 0.88'
+  seed: 11235
+
+operator_projection_targets:
+  - name: GPT-memory-channel
+    coupling: "j^μ_semantic ↔ GPT(embedding_t)"
+    condition: "maintain ∂_μ j^μ > 0 in shock zones"
+
+  - name: attractor-stability-gradient
+    evolution_target: "∂²𝓛/∂Φ² ↔ 0"
+    chaos_filter: dynamic law suppression
+
+operator_mutation_rules:
+  - name: law_spectrum_sparsifier
+    function: "drop modes with spectral entropy > 0.85"
+    gating: GPT-informed
+
+  - name: torsion_nonlinear_folding
+    formula: "T^μ ↔ tanh(∇ log γ) + η sin(Φ)"
+    η: 0.15
+
+fitness_evaluation:
+  semantic_continuity: '> 0.93'
+  GPT_law_entropy_divergence: bounded
+  chaos_survivability_index: '> 0.9'
+
+mutate:
+  operator_weights: [0.14, -0.08, 0.06, -0.05, 0.02]
+  shift_basis: true
+  reproject_after: true

--- a/configs/law_training/suggestion_hybrid_torsion_mirror_lock.yaml
+++ b/configs/law_training/suggestion_hybrid_torsion_mirror_lock.yaml
@@ -1,0 +1,37 @@
+metadata:
+  version: 2.1
+  description: Mirror torsion alignment under recursive vortex pressure
+
+global_settings:
+  torsion_sync_mode: bilateral
+  symmetry_weight: 0.9
+  seed: 9001
+
+operator_projection_targets:
+  - name: torsion-twin
+    equation: "𝒯^μ ↔ 𝒯^{μ*} + δ ∂^μ log(γ_PT)"
+    δ: 0.017
+    enforce_frequency: 3
+
+  - name: spiral_curvature_balance
+    condition: "∇ × j^μ_semantic = ∇ × j^μ_PT"
+
+operator_mutation_rules:
+  - name: chi_reflection_bias
+    function: "χ(t) ↔ χ_PT(t) * (1 ± ε)"
+    ε: 0.007
+    apply_to: attractor threshold crossings
+
+  - name: PT-shell_resonance
+    form: "Ψ ↔ e^{-iθ(t)} Ψ*"
+    θ(t): tan(γ) mod 2π
+
+fitness_evaluation:
+  mirror_torsion_error: '< 0.005'
+  PT_resonance_frequency_lock: "> 0.97"
+  vortex_collapse_asymmetry: '< 0.03'
+
+mutate:
+  operator_weights: [-0.02, 0.05, -0.03, 0.04, -0.01]
+  shift_basis: true
+  reproject_after: true

--- a/configs/law_training/suggestion_template.yaml
+++ b/configs/law_training/suggestion_template.yaml
@@ -1,0 +1,75 @@
+metadata:
+  version: 1.0
+  description: >-
+    Template for GPT-guided operator projection conditioning.
+    Defines semantic alignment, mutation biases, and torsion preferences.
+
+global_settings:
+  random_seed: 1337
+  apply_softmax_bias: true
+  mutation_temperature: 0.15
+
+operator_projection_targets:
+  - name: torsion_alignment
+    type: ψ-gradient
+    target_vector: "∇ arg(Ψ)"
+    alignment_goal: maximize
+    importance_weight: 0.9
+
+  - name: curvature_cancellation
+    type: semantic
+    target_tensor: "∂²χ"
+    goal: minimize
+    weight: 0.75
+
+  - name: coherence_memory_lock
+    type: flux-persistence
+    field: "γ"
+    projection_basis: "torsion_eigenmodes"
+    constraint: "Preserve loop entropy below 0.12"
+
+  - name: mirror_self_duality
+    type: PT-dual
+    condition: "Im[Ψ] ↔ -Im[Ψ]"
+    goal: enforce_symmetry
+    jitter_tolerance: 0.04
+
+operator_mutation_rules:
+  - name: soft_spiral_torsion
+    mutation_type: additive
+    function: "sin(ωr + φ)"
+    parameters:
+      ω: 2.0
+      φ: π/6
+    apply_to: torsion_channel
+    bias: moderate
+
+  - name: χ-density_pulse
+    mutation_type: Gaussian-bump
+    center: r=4.2
+    amplitude: 0.05
+    sigma: 0.8
+    apply_to: χ_field
+    condition: "only if ∂χ/∂t < 0"
+
+  - name: γ-spiral_resonance_shift
+    mutation_type: phase_twist
+    equation: "γ(r) *= exp(i * α * sin(θ))"
+    α: 0.07
+    domain: (r, θ)
+
+fitness_evaluation:
+  hysteresis_loop_area: minimize
+  torsion_norm_stability: threshold < 0.42
+  echo_mass_conservation: soft_constraint
+  projection_overlap_consistency: enforce > 0.95
+
+notes:
+  - Ensure suggestions remain within causal zone (τ < τ_collapse).
+  - Avoid symmetry violation across γ < 0.01 unless testing entropy escape.
+  - Re-evaluate law convergence every 12 epochs or 40 iterations.
+
+mutate:
+  operator_weights: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  shift_basis: true
+  reproject_after: true

--- a/configs/law_training/suggestion_variant_entropy_max.yaml
+++ b/configs/law_training/suggestion_variant_entropy_max.yaml
@@ -1,0 +1,43 @@
+metadata:
+  version: 1.1
+  description: Entropy-maximising operator bias template
+
+global_settings:
+  mutation_temperature: 0.45
+  bias_strategy: entropy_gradient_ascent
+  seed: 777
+
+operator_projection_targets:
+  - name: decoherence_ramp
+    type: χ-modulation
+    projection: "∂χ/∂t"
+    goal: maximize
+    weight: 1.0
+
+  - name: torsion_uncurling
+    type: vortex_loosen
+    constraint: "∇ × T^μ → 0"
+    bias: strong
+
+operator_mutation_rules:
+  - name: ψ_scrambler
+    mutation_type: Fourier-ripple
+    frequency_band: [1.5, 7.2]
+    apply_to: Im[Ψ]
+    jitter: 0.15
+
+  - name: golden_divergence_injection
+    equation: "∂μ j^μ += φ * ∇ log γ"
+    φ: 1.618
+    apply_to: semantic_current
+    bias: extreme
+
+fitness_evaluation:
+  total_entropy: maximize
+  spectral_flatness: enforce > 0.92
+  χ-gradient_mobility: loosen >= 0.3
+
+mutate:
+  operator_weights: [0.18, 0.07, -0.12, 0.05, -0.03]
+  shift_basis: true
+  reproject_after: true

--- a/configs/law_training/suggestion_variant_law_cycle.yaml
+++ b/configs/law_training/suggestion_variant_law_cycle.yaml
@@ -1,0 +1,36 @@
+metadata:
+  version: 1.2
+  description: Law-cycling template for periodic attractor traversal
+
+global_settings:
+  mutation_temperature: 0.25
+  periodicity_bias: enabled
+  seed: 31415
+
+operator_projection_targets:
+  - name: loop_phasor
+    type: law_phase
+    target_angle: "arg(𝓛)"
+    recurrence_goal: periodic
+    period: 5
+
+  - name: law_orbit_radius
+    type: attractor_distance
+    constraint: "oscillate in [0.1, 0.35]"
+
+operator_mutation_rules:
+  - name: gamma_resonator
+    function: "γ(r) *= sin(ω t + φ)"
+    ω: 1.2566370614
+    φ: 0.3926990817
+    feedback: hysteresis loop amplitude
+
+fitness_evaluation:
+  loop_closure_integral: minimize_drift
+  cycle_entropy_gain: '< 0.01 per orbit'
+  recurrence_fidelity: "> 0.95"
+
+mutate:
+  operator_weights: [0.05, -0.02, 0.08, -0.04, 0.01]
+  shift_basis: true
+  reproject_after: true

--- a/configs/law_training/suggestion_variant_mirror_sync.yaml
+++ b/configs/law_training/suggestion_variant_mirror_sync.yaml
@@ -1,0 +1,36 @@
+metadata:
+  version: 1.3
+  description: Mirror sector synchronization for law duality
+
+global_settings:
+  softmax_reinforcement: true
+  mirror_state_tie: enforce
+  seed: 8888
+
+operator_projection_targets:
+  - name: PT-alignment
+    type: conjugate
+    equation: "Ψ ↔ Ψ*"
+    symmetry_goal: enforce_mirror_match
+
+  - name: entropic_balance
+    type: χ-dual
+    equation: "χ_PT = χ"
+    tolerance: 0.01
+
+operator_mutation_rules:
+  - name: symmetry_lock
+    function: "Ψ ↔ e^{-iθ} Ψ*"
+    θ: 0.7853981634
+    apply_to: all_sectors
+    bias: high
+
+fitness_evaluation:
+  entropy_symmetry_error: '< 0.005'
+  torsion_dual_norm: match_within_2_percent
+  reflection_fidelity: "> 0.99"
+
+mutate:
+  operator_weights: [-0.04, 0.04, -0.01, 0.03, -0.05]
+  shift_basis: true
+  reproject_after: true

--- a/law_operator_training.py
+++ b/law_operator_training.py
@@ -1,0 +1,284 @@
+"""Law operator training utilities for GPT-integrated law evolution workflows.
+
+This module exposes the :class:`LawOperatorTrainer`, a lightweight harness that
+compresses high dimensional law tensors into GPT manageable operator tokens,
+allows semantic projections, visualises operator drift and integrates external
+GPT guidance loops.
+"""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import h5py
+import numpy as np
+import yaml
+from sklearn.decomposition import PCA
+
+
+@dataclass
+class _PCAMetadata:
+    """Container that stores PCA artefacts required for reconstruction."""
+
+    components: np.ndarray
+    mean: np.ndarray
+
+
+class LawOperatorTrainer:
+    """Distil law tensors into GPT-accessible operator representations."""
+
+    def __init__(
+        self,
+        law_field_file: str,
+        n_components: int = 5,
+        random_seed: Optional[int] = None,
+    ) -> None:
+        self.law_field_file = law_field_file
+        self.n_components = n_components
+        self.random_seed = random_seed
+        self.operators: Optional[np.ndarray] = None
+        self.law_tensor: Optional[np.ndarray] = None
+        self.meta: Dict[str, Any] = {}
+        self._pca_model: Optional[PCA] = None
+        self._pca_meta: Optional[_PCAMetadata] = None
+
+    # ------------------------------------------------------------------
+    # Data IO helpers
+    # ------------------------------------------------------------------
+    def load_law_field(self) -> np.ndarray:
+        """Load the law tensor from the checkpoint file."""
+        with h5py.File(self.law_field_file, "r") as f:
+            if "law_tensor" not in f:
+                raise KeyError("Missing 'law_tensor' dataset in checkpoint")
+            self.law_tensor = f["law_tensor"][:]
+            self.meta["coords"] = {key: f.attrs[key] for key in f.attrs}
+        return self.law_tensor
+
+    # ------------------------------------------------------------------
+    # Core dimensionality reduction
+    # ------------------------------------------------------------------
+    def reduce_operators(self) -> np.ndarray:
+        """Perform PCA over the law tensor to obtain operator trajectories."""
+        if self.law_tensor is None:
+            raise RuntimeError("Law tensor not loaded. Call 'load_law_field' first.")
+
+        t_steps, radial, angular = self.law_tensor.shape
+        flattened = self.law_tensor.reshape(t_steps, radial * angular)
+
+        self._pca_model = PCA(n_components=self.n_components, svd_solver="full")
+        self.operators = self._pca_model.fit_transform(flattened)
+        self._pca_meta = _PCAMetadata(
+            components=self._pca_model.components_.copy(),
+            mean=self._pca_model.mean_.copy(),
+        )
+        self.meta["pca_explained_variance"] = self._pca_model.explained_variance_.tolist()
+        return self.operators
+
+    # ------------------------------------------------------------------
+    # Semantic projection
+    # ------------------------------------------------------------------
+    def add_semantic_projection_layer(
+        self, j_mu_file: str, coupling_weight: float = 0.618
+    ) -> np.ndarray:
+        """Project the law tensor into a semantic basis driven by ``j^μ`` fields."""
+        if self.law_tensor is None:
+            raise RuntimeError("Law tensor not loaded. Call 'load_law_field' first.")
+
+        with h5py.File(j_mu_file, "r") as f:
+            if "j_semantic" not in f:
+                raise KeyError("Missing 'j_semantic' dataset in semantic file")
+            j_mu = f["j_semantic"][:]
+
+        norm = np.linalg.norm(j_mu, axis=-1)
+        if norm.shape != self.law_tensor.shape:
+            raise ValueError(
+                "Semantic current shape does not match law tensor shape."
+            )
+
+        projected_tensor = self.law_tensor * (1.0 + coupling_weight * norm)
+        flattened = projected_tensor.reshape(projected_tensor.shape[0], -1)
+
+        self._pca_model = PCA(n_components=self.n_components, svd_solver="full")
+        self.operators = self._pca_model.fit_transform(flattened)
+        self._pca_meta = _PCAMetadata(
+            components=self._pca_model.components_.copy(),
+            mean=self._pca_model.mean_.copy(),
+        )
+        self.meta["semantic_projection"] = {
+            "j_mu_file": j_mu_file,
+            "coupling_weight": coupling_weight,
+        }
+        return self.operators
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+    def export_gpt_tokens(self, out_file: str = "law_tokens.yaml") -> Dict[str, Any]:
+        """Persist operator tokens to a YAML file."""
+        if self.operators is None:
+            raise RuntimeError("Operators not available. Run reduction first.")
+
+        tokens = {f"𝒪_{i}": self.operators[:, i].tolist() for i in range(self.n_components)}
+        payload = {"law_tokens": tokens, "meta": self.meta}
+        with open(out_file, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=True)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Operator diagnostics and utilities
+    # ------------------------------------------------------------------
+    def plot_operator_drift(self, out_file: str = "operator_drift.png") -> None:
+        """Plot the temporal drift of each operator trajectory."""
+        if self.operators is None:
+            raise RuntimeError("Operators not available. Run reduction first.")
+
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        t_steps = self.operators.shape[0]
+        plt.figure(figsize=(10, 6))
+        for idx in range(self.n_components):
+            plt.plot(range(t_steps), self.operators[:, idx], label=f"𝒪_{idx}")
+        plt.xlabel("Time Step")
+        plt.ylabel("Operator Value")
+        plt.title("Evolution of Law Operators (𝒪ᵢ)")
+        plt.grid(True)
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(out_file)
+
+    def attach_gpt_guidance(
+        self, suggestion_file: str, influence_strength: float = 0.25
+    ) -> None:
+        """Inject GPT supplied mutations over the operator basis."""
+        if self.operators is None:
+            raise RuntimeError("Operators not available. Run reduction first.")
+
+        with open(suggestion_file, "r", encoding="utf-8") as handle:
+            gpt_cfg = yaml.safe_load(handle)
+
+        if "mutate" not in gpt_cfg:
+            raise ValueError("Suggestion file missing 'mutate' directive")
+
+        guidance = gpt_cfg["mutate"]
+        op_weights: List[float] = guidance.get(
+            "operator_weights", [0.0] * self.n_components
+        )
+        shift_basis: bool = guidance.get("shift_basis", False)
+        reproject: bool = guidance.get("reproject_after", True)
+
+        if len(op_weights) != self.n_components:
+            raise ValueError(
+                f"Expected {self.n_components} operator weights, received {len(op_weights)}"
+            )
+
+        bias_vector = np.asarray(op_weights, dtype=float) * float(influence_strength)
+        self.operators = self.operators + bias_vector[np.newaxis, :]
+
+        if shift_basis:
+            self._recenter_operator_basis()
+        if reproject:
+            self.reproject_operators_to_law()
+
+        self.meta["gpt_guidance"] = {
+            "source": suggestion_file,
+            "strength": influence_strength,
+            "bias_applied": op_weights,
+            "shift_basis": shift_basis,
+        }
+
+    def reproject_operators_to_law(self) -> np.ndarray:
+        """Reconstruct the law tensor from the current operators."""
+        if self.operators is None or self._pca_model is None:
+            raise RuntimeError("Operators or PCA model unavailable for reprojection.")
+
+        reconstructed = self._pca_model.inverse_transform(self.operators)
+        if self.law_tensor is None:
+            raise RuntimeError("Law tensor shape unknown. Load checkpoint first.")
+
+        self.law_tensor = reconstructed.reshape(self.law_tensor.shape)
+        return self.law_tensor
+
+    def clone(self) -> "LawOperatorTrainer":
+        """Return a deep copy of the trainer with duplicated state."""
+        clone = LawOperatorTrainer(
+            self.law_field_file, self.n_components, random_seed=self.random_seed
+        )
+        if self.law_tensor is not None:
+            clone.law_tensor = self.law_tensor.copy()
+        if self.operators is not None:
+            clone.operators = self.operators.copy()
+        if self._pca_model is not None:
+            clone._pca_model = deepcopy(self._pca_model)
+        if self._pca_meta is not None:
+            clone._pca_meta = deepcopy(self._pca_meta)
+        clone.meta = deepcopy(self.meta)
+        return clone
+
+    def generate_token_batch(
+        self, prompts_yaml: str, output_dir: str = "tokens_batch", seed: Optional[int] = 42
+    ) -> None:
+        """Generate batches of GPT token streams under variant prompt mutations."""
+        if self.operators is None:
+            raise RuntimeError("Operators not available. Run reduction first.")
+
+        os.makedirs(output_dir, exist_ok=True)
+        with open(prompts_yaml, "r", encoding="utf-8") as handle:
+            prompt_list = yaml.safe_load(handle) or []
+
+        rng = np.random.default_rng(seed)
+        for idx, prompt in enumerate(prompt_list):
+            name = prompt.get("name", f"token_stream_{idx}")
+            prompt_path = os.path.join(
+                output_dir, f"{name.replace(' ', '_')}.yaml"
+            )
+            with open(prompt_path, "w", encoding="utf-8") as destination:
+                yaml.safe_dump(prompt, destination, sort_keys=False)
+
+            trainer_clone = self.clone()
+            influence = prompt.get("influence_strength", 0.4)
+            if "mutate" in prompt:
+                trainer_clone.attach_gpt_guidance(
+                    prompt_path, influence_strength=influence
+                )
+            token_file = os.path.join(output_dir, f"law_tokens_{idx}.yaml")
+            drift_file = os.path.join(output_dir, f"drift_{idx}.png")
+            trainer_clone.export_gpt_tokens(token_file)
+            trainer_clone.plot_operator_drift(drift_file)
+
+            noise = float(rng.normal(0, 1e-12))
+            trainer_clone.meta.setdefault("batch_noise", []).append(noise)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+    def get_operator_basis(self) -> np.ndarray:
+        if self._pca_meta is None:
+            raise RuntimeError("Operator basis unavailable. Run reduction first.")
+        return self._pca_meta.components.copy()
+
+    def _recenter_operator_basis(self) -> None:
+        if self.operators is None or self._pca_model is None:
+            raise RuntimeError("Operators not available to recenter basis.")
+
+        flattened = self._pca_model.inverse_transform(self.operators)
+        self._pca_model = PCA(n_components=self.n_components, svd_solver="full")
+        self.operators = self._pca_model.fit_transform(flattened)
+        self._pca_meta = _PCAMetadata(
+            components=self._pca_model.components_.copy(),
+            mean=self._pca_model.mean_.copy(),
+        )
+
+    def shift_operator_basis(self) -> None:
+        """Alias retained for backwards compatibility."""
+        self._recenter_operator_basis()
+
+    def reproject_onto_basis(self) -> np.ndarray:
+        return self.reproject_operators_to_law()
+
+
+__all__ = ["LawOperatorTrainer"]

--- a/tests/test_encoding_reproducibility.py
+++ b/tests/test_encoding_reproducibility.py
@@ -1,0 +1,67 @@
+import numpy as np
+import yaml
+import pytest
+
+h5py = pytest.importorskip("h5py")
+
+from law_operator_training import LawOperatorTrainer
+
+
+def _create_law_checkpoint(path):
+    time_steps, radial, angular = 8, 3, 2
+    grid = np.linspace(0.0, 1.0, time_steps * radial * angular)
+    law_tensor = grid.reshape(time_steps, radial, angular)
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset("law_tensor", data=law_tensor)
+        handle.attrs["time"] = time_steps
+        handle.attrs["radial"] = radial
+        handle.attrs["angular"] = angular
+    return law_tensor
+
+
+def test_operator_encoding_determinism(tmp_path):
+    law_path = tmp_path / "chk_law_tensor.h5"
+    _create_law_checkpoint(law_path)
+
+    trainer = LawOperatorTrainer(str(law_path), n_components=3)
+    trainer.load_law_field()
+    trainer.reduce_operators()
+
+    tokens_a = trainer.export_gpt_tokens(tmp_path / "tokens_a.yaml")
+    tokens_b = trainer.export_gpt_tokens(tmp_path / "tokens_b.yaml")
+
+    assert tokens_a == tokens_b
+    with (
+        open(tmp_path / "tokens_a.yaml", "r", encoding="utf-8") as handle_a,
+        open(tmp_path / "tokens_b.yaml", "r", encoding="utf-8") as handle_b,
+    ):
+        assert yaml.safe_load(handle_a) == yaml.safe_load(handle_b)
+
+
+def test_operator_reprojection_consistency(tmp_path):
+    law_path = tmp_path / "chk_law_tensor.h5"
+    law_tensor = _create_law_checkpoint(law_path)
+
+    suggestion = tmp_path / "suggestion.yaml"
+    with open(suggestion, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(
+            {
+                "mutate": {
+                    "operator_weights": [0.0, 0.0, 0.0],
+                    "shift_basis": True,
+                    "reproject_after": True,
+                }
+            },
+            handle,
+        )
+
+    trainer = LawOperatorTrainer(str(law_path), n_components=3)
+    trainer.load_law_field()
+    trainer.reduce_operators()
+
+    baseline = trainer.reproject_operators_to_law().copy()
+    trainer.attach_gpt_guidance(str(suggestion), influence_strength=0.5)
+    reprojection = trainer.reproject_operators_to_law()
+
+    assert np.allclose(baseline, law_tensor)
+    assert np.allclose(reprojection, law_tensor)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py38, py39
+
+[testenv]
+deps =
+    pytest
+    numpy
+    h5py
+    pyyaml
+    matplotlib
+commands =
+    pytest


### PR DESCRIPTION
## Summary
- add a law operator training harness with semantic projection, GPT guidance, and batch token generation helpers
- provide reusable GPT guidance templates for entropy, cyclic, mirror, and hybrid law evolutions
- introduce reproducibility-focused tests alongside tox and CI wiring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e73767bc78832ca19575ca4340a6d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a trainer to reduce high‑dimensional law data, export operator tokens, apply guidance, plot drift, and reproject results with deterministic behavior.
- Configuration
  - Added multiple training presets and a template for entropy‑driven, cyclic, mirror‑sync, chaos‑sieve, and torsion‑mirror workflows with evaluation metrics and mutation controls.
- Tests
  - Added tests ensuring deterministic token export and consistent reprojection with and without guidance.
- Chores
  - Set up continuous integration to run tests on supported Python versions.
  - Added tox environments for streamlined local testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->