### PR TITLE
Add semantic energy accounting helpers

### DIFF
--- a/pkgs/core_physics/__init__.py
+++ b/pkgs/core_physics/__init__.py
@@ -14,6 +14,14 @@ from .utils import _ddx, _ddy, _hypercube_bits, _embed_4d_to_2d, RGPlanner, Gyro
 # Field theory components
 from .fields import UVIRRegulator, AlenaSoul, ProperTimeGaugeField
 
+# Energy accounting
+from .energy import (
+    semantic_energy_density,
+    semantic_energy_total,
+    semantic_energy_dissipation_density,
+    semantic_energy_dissipation_total,
+)
+
 # Control systems
 from .control import SignatureNormalizer, JacobianHypercube
 
@@ -32,7 +40,10 @@ __all__ = [
     # Utils
     '_ddx', '_ddy', '_hypercube_bits', '_embed_4d_to_2d', 'RGPlanner', 'GyroscopeFeeler',
     # Fields
-    'UVIRRegulator', 'AlenaSoul', 'ProperTimeGaugeField', 
+    'UVIRRegulator', 'AlenaSoul', 'ProperTimeGaugeField',
+    # Energy helpers
+    'semantic_energy_density', 'semantic_energy_total',
+    'semantic_energy_dissipation_density', 'semantic_energy_dissipation_total',
     # Control
     'SignatureNormalizer', 'JacobianHypercube',
     # Time operations

--- a/pkgs/core_physics/energy.py
+++ b/pkgs/core_physics/energy.py
@@ -1,0 +1,159 @@
+r"""Utilities for computing semantic energy flows in coherence fields.
+
+This module implements helper functions that estimate the energetic cost of
+updating the coherence factor :math:`\gamma` that appears throughout the RCC
+pipeline.  The routines follow the specification provided in the research
+notes: the gradient of ``log(gamma)`` acts as a coherence pressure whose energy
+cost scales with the semantic density ``|psi|**2`` and a coupling constant
+``kappa``.
+
+The helpers return NumPy arrays so that the results can be consumed by both the
+NumPy based diagnostic tools and the Torch driven simulation core.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Tuple, Union
+
+import numpy as np
+
+ArrayLike = Union[np.ndarray, Sequence[float]]
+
+
+def _normalise_spacing(spacing: Union[float, Sequence[float]], ndim: int) -> Tuple[float, ...]:
+    """Normalise the spacing argument for ``numpy.gradient``.
+
+    Parameters
+    ----------
+    spacing:
+        Either a single float (applied to every dimension) or a sequence with
+        one entry per dimension.
+    ndim:
+        Number of spatial dimensions in the field that is being processed.
+    """
+    if np.isscalar(spacing):
+        return tuple(float(spacing) for _ in range(ndim))
+
+    spacing_tuple = tuple(float(s) for s in spacing)
+    if len(spacing_tuple) != ndim:
+        raise ValueError(
+            f"Expected spacing for {ndim} dimensions, received {len(spacing_tuple)} entries."
+        )
+    return spacing_tuple
+
+
+def _gradient_log_gamma(log_gamma: np.ndarray, spacing: Tuple[float, ...]) -> Tuple[np.ndarray, ...]:
+    """Compute the gradient of ``log_gamma`` with the requested spacing."""
+    gradients = np.gradient(log_gamma, *spacing, edge_order=2)
+    # ``np.gradient`` returns an ndarray for 1D input, so normalise to a tuple
+    if isinstance(gradients, np.ndarray):
+        return (gradients,)
+    return tuple(gradients)
+
+
+def semantic_energy_density(
+    psi: ArrayLike,
+    gamma: ArrayLike,
+    spacing: Union[float, Sequence[float]] = 1.0,
+    kappa: float = 1.0,
+) -> np.ndarray:
+    """Return the point-wise semantic energy density produced by ``∇log γ``.
+
+    Parameters
+    ----------
+    psi:
+        Complex (or real) semantic field whose magnitude encodes the semantic
+        density ``|psi|**2``.
+    gamma:
+        Coherence field.  Must have the same shape as ``psi``.
+    spacing:
+        Grid spacing used for the finite-difference gradient.  Either a single
+        value (applied uniformly) or one value per dimension.
+    kappa:
+        Coupling constant that scales how strongly the coherence gradient feeds
+        into the energy budget.
+    """
+    psi_arr = np.asarray(psi)
+    gamma_arr = np.asarray(gamma)
+
+    if psi_arr.shape != gamma_arr.shape:
+        raise ValueError(
+            "psi and gamma must share the same shape for semantic energy computation."
+        )
+
+    log_gamma = np.log(np.clip(gamma_arr, 1e-12, None))
+    spacing_tuple = _normalise_spacing(spacing, log_gamma.ndim)
+    grad_components = _gradient_log_gamma(log_gamma, spacing_tuple)
+    grad_sq = sum(comp**2 for comp in grad_components)
+
+    rho_sem = np.abs(psi_arr) ** 2
+    return 0.5 * (kappa**2) * rho_sem * grad_sq
+
+
+def semantic_energy_total(
+    psi: ArrayLike,
+    gamma: ArrayLike,
+    spacing: Union[float, Sequence[float]] = 1.0,
+    kappa: float = 1.0,
+) -> float:
+    """Integrate :func:`semantic_energy_density` over the full grid."""
+    density = semantic_energy_density(psi, gamma, spacing=spacing, kappa=kappa)
+    spacing_tuple = _normalise_spacing(spacing, density.ndim)
+    volume_element = float(np.prod(spacing_tuple))
+    return float(np.sum(density) * volume_element)
+
+
+def semantic_energy_dissipation_density(
+    psi: ArrayLike,
+    gamma: ArrayLike,
+    torsion: ArrayLike,
+    spacing: Union[float, Sequence[float]] = 1.0,
+    kappa: float = 1.0,
+    coupling: float = 1.0,
+) -> np.ndarray:
+    """Return the torsion-coupled energy dissipation density.
+
+    This implements the integrand ``-λ κ² |psi|² T^μ ∂_μ log γ`` from the design
+    notes.  ``torsion`` must be an array whose first dimension enumerates the
+    spatial components of ``T^μ`` (i.e. ``torsion.shape[0] == gamma.ndim``).
+    """
+    psi_arr = np.asarray(psi)
+    gamma_arr = np.asarray(gamma)
+    torsion_arr = np.asarray(torsion)
+
+    if psi_arr.shape != gamma_arr.shape:
+        raise ValueError("psi and gamma must have identical shapes.")
+
+    spacing_tuple = _normalise_spacing(spacing, gamma_arr.ndim)
+    grad_components = _gradient_log_gamma(
+        np.log(np.clip(gamma_arr, 1e-12, None)), spacing_tuple
+    )
+
+    if torsion_arr.shape[0] != len(grad_components):
+        raise ValueError(
+            "torsion must provide one component per spatial dimension (shape[0] == gamma.ndim)."
+        )
+
+    # Broadcast torsion components against the gradient components.
+    dot_product = np.zeros_like(gamma_arr, dtype=float)
+    for idx, grad_component in enumerate(grad_components):
+        dot_product += np.asarray(torsion_arr[idx]) * grad_component
+
+    rho_sem = np.abs(psi_arr) ** 2
+    return -coupling * (kappa**2) * rho_sem * dot_product
+
+
+def semantic_energy_dissipation_total(
+    psi: ArrayLike,
+    gamma: ArrayLike,
+    torsion: ArrayLike,
+    spacing: Union[float, Sequence[float]] = 1.0,
+    kappa: float = 1.0,
+    coupling: float = 1.0,
+) -> float:
+    """Integrate :func:`semantic_energy_dissipation_density` over the grid."""
+    density = semantic_energy_dissipation_density(
+        psi, gamma, torsion, spacing=spacing, kappa=kappa, coupling=coupling
+    )
+    spacing_tuple = _normalise_spacing(spacing, density.ndim)
+    volume_element = float(np.prod(spacing_tuple))
+    return float(np.sum(density) * volume_element)

--- a/tests/test_semantic_energy.py
+++ b/tests/test_semantic_energy.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+
+from pkgs.core_physics.energy import (
+    semantic_energy_density,
+    semantic_energy_total,
+    semantic_energy_dissipation_density,
+    semantic_energy_dissipation_total,
+)
+
+
+def test_semantic_energy_density_matches_expected_one_dimensional():
+    x = np.linspace(0.0, 1.0, 5)
+    dx = x[1] - x[0]
+    gamma = np.exp(0.5 * x)
+    psi = np.ones_like(gamma, dtype=np.complex128)
+
+    density = semantic_energy_density(psi, gamma, spacing=dx, kappa=0.5)
+
+    log_gamma = np.log(gamma)
+    grad = np.gradient(log_gamma, dx, edge_order=2)
+    expected = 0.5 * (0.5**2) * np.abs(psi) ** 2 * grad**2
+
+    np.testing.assert_allclose(density, expected)
+
+
+def test_semantic_energy_total_includes_volume_element():
+    x = np.linspace(-1.0, 1.0, 11)
+    dx = x[1] - x[0]
+    gamma = 1.0 + 0.1 * x**2
+    psi = 0.25 + 0.5j * np.ones_like(gamma)
+
+    density = semantic_energy_density(psi, gamma, spacing=dx, kappa=1.2)
+    expected_total = float(np.sum(density) * dx)
+    total = semantic_energy_total(psi, gamma, spacing=dx, kappa=1.2)
+
+    assert pytest.approx(expected_total, rel=1e-12) == total
+
+
+def test_semantic_energy_density_raises_for_mismatched_shapes():
+    psi = np.ones((4, 4))
+    gamma = np.ones((4, 3))
+    with pytest.raises(ValueError):
+        semantic_energy_density(psi, gamma)
+
+
+@pytest.mark.parametrize("spacing", [1.0, (0.2, 0.5)])
+def test_semantic_energy_dissipation_density_matches_formula(spacing):
+    shape = (6, 7)
+    gamma = np.exp(0.2 * np.add.outer(np.linspace(0, 1, shape[0]), np.linspace(0, 1, shape[1])))
+    psi = np.ones(shape, dtype=np.complex128)
+
+    grad_spacing = spacing
+    density = semantic_energy_dissipation_density(
+        psi,
+        gamma,
+        torsion=np.array([
+            np.full(shape, 0.3),
+            np.full(shape, -0.1),
+        ]),
+        spacing=grad_spacing,
+        kappa=1.0,
+        coupling=0.2,
+    )
+
+    spacing_tuple = (spacing, spacing) if np.isscalar(spacing) else spacing
+    grad_log_gamma = np.gradient(np.log(gamma), *spacing_tuple, edge_order=2)
+    if isinstance(grad_log_gamma, np.ndarray):
+        grad_log_gamma = (grad_log_gamma,)
+
+    dot = 0.3 * grad_log_gamma[0] + (-0.1) * grad_log_gamma[1]
+    expected = -0.2 * (np.abs(psi) ** 2) * dot
+
+    np.testing.assert_allclose(density, expected)
+
+
+def test_semantic_energy_dissipation_total_respects_spacing():
+    shape = (8,)
+    dx = 0.125
+    gamma = np.exp(0.3 * np.linspace(0, 1, shape[0]))
+    psi = np.ones(shape)
+    torsion = np.array([np.full(shape, 0.05)])
+
+    density = semantic_energy_dissipation_density(psi, gamma, torsion, spacing=dx, coupling=0.4)
+    expected_total = float(np.sum(density) * dx)
+    total = semantic_energy_dissipation_total(psi, gamma, torsion, spacing=dx, coupling=0.4)
+    assert pytest.approx(expected_total, rel=1e-12) == total
+
+
+def test_semantic_energy_dissipation_requires_matching_component_count():
+    gamma = np.ones((3, 3))
+    psi = np.ones_like(gamma)
+    torsion = np.ones((3, 3, 3))  # Incorrect shape: first dimension must equal ndim (2)
+    with pytest.raises(ValueError):
+        semantic_energy_dissipation_density(psi, gamma, torsion)


### PR DESCRIPTION
## Summary
- add a core physics energy module that computes semantic energy density and torsion-coupled dissipation from ∇log γ
- expose the new helpers through the core physics package for external use
- cover the new logic with dedicated pytest unit tests for density, totals, and error handling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e75b0ffdb8832c987fd6f31a2ae61a