### PR TITLE
Add RCC law dashboard scaffolding

### DIFF
--- a/law_tools/__init__.py
+++ b/law_tools/__init__.py
@@ -1,0 +1,14 @@
+"""Toolkit for RCC law dashboards and GPT operator control."""
+
+from importlib import metadata
+
+
+def get_version() -> str:
+    """Return the package version if installed, otherwise ``'0.0.0'``."""
+    try:
+        return metadata.version("law_tools")
+    except metadata.PackageNotFoundError:  # pragma: no cover - fallback for source usage
+        return "0.0.0"
+
+
+__all__ = ["get_version"]

--- a/law_tools/backend/__init__.py
+++ b/law_tools/backend/__init__.py
@@ -1,0 +1,14 @@
+"""Backend helpers for law dashboards."""
+
+from .hdf_bridge import LawCheckpoint, load_checkpoint, iter_dataset_names, load_additional_field
+from .live_hooks import LawEvent, LiveHookBus, LiveLawState
+
+__all__ = [
+    "LawCheckpoint",
+    "load_checkpoint",
+    "iter_dataset_names",
+    "load_additional_field",
+    "LawEvent",
+    "LiveHookBus",
+    "LiveLawState",
+]

--- a/law_tools/backend/hdf_bridge.py
+++ b/law_tools/backend/hdf_bridge.py
@@ -1,0 +1,66 @@
+"""Utility helpers for reading RCC checkpoint data structures."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Tuple
+
+import h5py
+import numpy as np
+
+
+@dataclass
+class LawCheckpoint:
+    """Lightweight container describing the loaded checkpoint content."""
+
+    law_tensor: np.ndarray
+    metadata: Dict[str, Any]
+
+
+def _read_attrs(handle: h5py.File) -> Dict[str, Any]:
+    """Return a dictionary copy of the attributes on *handle*."""
+
+    attrs: Dict[str, Any] = {}
+    for key, value in handle.attrs.items():
+        if isinstance(value, bytes):
+            attrs[key] = value.decode("utf-8")
+        else:
+            attrs[key] = value
+    return attrs
+
+
+def load_checkpoint(path: str | Path, dataset: str = "law_tensor") -> LawCheckpoint:
+    """Load ``dataset`` from *path* and return :class:`LawCheckpoint`."""
+
+    checkpoint_path = Path(path)
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+
+    with h5py.File(checkpoint_path, "r") as handle:
+        if dataset not in handle:
+            raise KeyError(f"Dataset '{dataset}' missing in checkpoint {checkpoint_path}")
+        tensor = handle[dataset][:]
+        metadata = _read_attrs(handle)
+    return LawCheckpoint(law_tensor=tensor, metadata=metadata)
+
+
+def iter_dataset_names(path: str | Path) -> Iterable[str]:
+    """Yield dataset names contained in the checkpoint."""
+
+    with h5py.File(path, "r") as handle:
+        for name in handle.keys():
+            yield name
+
+
+def load_additional_field(path: str | Path, field: str) -> Tuple[np.ndarray, Dict[str, Any]]:
+    """Load a secondary field from the checkpoint returning data and attrs."""
+
+    with h5py.File(path, "r") as handle:
+        if field not in handle:
+            raise KeyError(f"Field '{field}' not present in checkpoint {path}")
+        data = handle[field][:]
+        attrs = _read_attrs(handle[field]) if isinstance(handle[field], h5py.Dataset) else {}
+    return data, attrs
+
+
+__all__ = ["LawCheckpoint", "load_checkpoint", "iter_dataset_names", "load_additional_field"]

--- a/law_tools/backend/live_hooks.py
+++ b/law_tools/backend/live_hooks.py
@@ -1,0 +1,69 @@
+"""Asynchronous event hooks bridging the RCC solver and dashboards."""
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable, Optional
+
+
+@dataclass
+class LawEvent:
+    """Simple event payload describing a solver update."""
+
+    name: str
+    payload: Dict[str, float]
+
+
+class LiveHookBus:
+    """Thread-safe publish/subscribe message bus for solver events."""
+
+    def __init__(self) -> None:
+        self._queue: "queue.Queue[LawEvent]" = queue.Queue()
+        self._subscribers: list[Callable[[LawEvent], None]] = []
+        self._stop = threading.Event()
+        self._worker: Optional[threading.Thread] = None
+
+    def publish(self, event: LawEvent) -> None:
+        self._queue.put(event)
+
+    def subscribe(self, callback: Callable[[LawEvent], None]) -> None:
+        self._subscribers.append(callback)
+
+    def start(self) -> None:
+        if self._worker and self._worker.is_alive():
+            return
+
+        def _run() -> None:
+            while not self._stop.is_set():
+                try:
+                    event = self._queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                for callback in list(self._subscribers):
+                    callback(event)
+
+        self._worker = threading.Thread(target=_run, daemon=True)
+        self._worker.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._worker and self._worker.is_alive():
+            self._worker.join(timeout=1.0)
+
+
+@dataclass
+class LiveLawState:
+    """Mutable container storing the latest law tensor snapshot."""
+
+    gamma_trace: list[float] = field(default_factory=list)
+    torsion_noise: float | None = None
+    hysteresis_depth: float | None = None
+
+    def update_from_tokens(self, tokens: Dict[str, float]) -> None:
+        self.gamma_trace.append(tokens.get("LAW_GAMMA_LEVEL", 0.0))
+        self.torsion_noise = tokens.get("LAW_TORSION_NOISE", self.torsion_noise)
+        self.hysteresis_depth = tokens.get("LAW_HYSTERESIS_DEPTH", self.hysteresis_depth)
+
+
+__all__ = ["LawEvent", "LiveHookBus", "LiveLawState"]

--- a/law_tools/backend/live_hooks.py
+++ b/law_tools/backend/live_hooks.py
@@ -34,6 +34,8 @@ class LiveHookBus:
         if self._worker and self._worker.is_alive():
             return
 
+        self._stop.clear()
+
         def _run() -> None:
             while not self._stop.is_set():
                 try:
@@ -50,7 +52,7 @@ class LiveHookBus:
         self._stop.set()
         if self._worker and self._worker.is_alive():
             self._worker.join(timeout=1.0)
-
+        self._worker = None
 
 @dataclass
 class LiveLawState:

--- a/law_tools/dashboard/__init__.py
+++ b/law_tools/dashboard/__init__.py
@@ -1,0 +1,17 @@
+"""Interactive dashboard utilities for RCC law inspection."""
+
+from .gamma_loop import GammaLoopResult, compute_gamma_loops
+from .torsion_map import TorsionMapResult, compute_torsion_map
+from .neuro_vis import NeuroSemanticTrace, build_neuro_semantic_trace
+from .echo_playback import EchoPlayback, build_echo_frames
+
+__all__ = [
+    "GammaLoopResult",
+    "compute_gamma_loops",
+    "TorsionMapResult",
+    "compute_torsion_map",
+    "NeuroSemanticTrace",
+    "build_neuro_semantic_trace",
+    "EchoPlayback",
+    "build_echo_frames",
+]

--- a/law_tools/dashboard/echo_playback.py
+++ b/law_tools/dashboard/echo_playback.py
@@ -1,0 +1,66 @@
+"""Temporal echo playback utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+try:  # pragma: no cover
+    import plotly.graph_objects as go
+except Exception:  # pragma: no cover
+    go = None
+
+
+@dataclass
+class EchoPlayback:
+    frames: np.ndarray
+    timestamps: np.ndarray
+
+
+def build_echo_frames(law_tensor: np.ndarray, stride: int = 1) -> EchoPlayback:
+    """Prepare frames for the temporal echo dashboard."""
+
+    if law_tensor.ndim != 3:
+        raise ValueError("Expected law tensor with shape [time, r, θ]")
+    frames = law_tensor[::stride]
+    timestamps = np.arange(frames.shape[0])
+    return EchoPlayback(frames=frames, timestamps=timestamps)
+
+
+def make_echo_animation(echo: EchoPlayback):  # pragma: no cover
+    if go is None:
+        raise RuntimeError("plotly is required for echo playback animations")
+
+    frames = []
+    for idx, frame in enumerate(echo.frames):
+        frames.append(
+            go.Frame(
+                data=[go.Heatmap(z=frame, colorscale="Plasma")],
+                name=str(idx),
+            )
+        )
+    fig = go.Figure(
+        data=[go.Heatmap(z=echo.frames[0], colorscale="Plasma")],
+        layout=go.Layout(
+            title="Temporal Echo Playback",
+            updatemenus=[
+                dict(
+                    type="buttons",
+                    buttons=[
+                        dict(label="Play", method="animate", args=[[str(i) for i in range(len(frames))]])
+                    ],
+                )
+            ],
+            sliders=[
+                dict(
+                    steps=[dict(method="animate", args=[[str(i)]], label=str(i)) for i in range(len(frames))]
+                )
+            ],
+        ),
+        frames=frames,
+    )
+    return fig
+
+
+__all__ = ["EchoPlayback", "build_echo_frames", "make_echo_animation"]

--- a/law_tools/dashboard/gamma_loop.py
+++ b/law_tools/dashboard/gamma_loop.py
@@ -1,0 +1,60 @@
+"""γ(r, θ) loop utilities for dashboard visualisation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import plotly.graph_objects as go
+except Exception:  # pragma: no cover - gracefully degrade when plotly missing
+    go = None
+
+
+@dataclass
+class GammaLoopResult:
+    r: np.ndarray
+    gamma_forward: np.ndarray
+    gamma_reverse: np.ndarray
+    loop_area: float
+
+
+def default_gamma_model(r: np.ndarray, y0: float, phi: float) -> np.ndarray:
+    """Base γ(r) profile used when no custom callable is provided."""
+
+    return np.cos(phi) * np.exp(-r / (1.5 + y0)) + np.sin(r * phi) * y0
+
+
+def compute_gamma_loops(
+    y0: float,
+    phi: float,
+    gamma: Callable[[np.ndarray, float, float], np.ndarray] | None = None,
+) -> GammaLoopResult:
+    """Compute forward and reverse γ(r) loops."""
+
+    gamma_fn = gamma or default_gamma_model
+    r_values = np.linspace(1.0, 10.0, 300)
+    gamma_forward = gamma_fn(r_values, y0, phi)
+    gamma_reverse = gamma_fn(r_values, y0, -phi)
+    loop_area = np.trapz(gamma_forward - gamma_reverse, r_values)
+    return GammaLoopResult(r=r_values, gamma_forward=gamma_forward, gamma_reverse=gamma_reverse, loop_area=float(loop_area))
+
+
+def make_gamma_figure(result: GammaLoopResult):  # pragma: no cover - plotting helper
+    if go is None:
+        raise RuntimeError("plotly is required to generate the gamma loop figure")
+
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=result.r, y=result.gamma_forward, mode="lines", name="γ_forward"))
+    fig.add_trace(go.Scatter(x=result.r, y=result.gamma_reverse, mode="lines", name="γ_reverse"))
+    fig.update_layout(
+        title=f"γ-loop integral (area = {result.loop_area:.3f})",
+        xaxis_title="r",
+        yaxis_title="γ(r)",
+        legend=dict(orientation="h"),
+    )
+    return fig
+
+
+__all__ = ["GammaLoopResult", "compute_gamma_loops", "make_gamma_figure", "default_gamma_model"]

--- a/law_tools/dashboard/gamma_loop.py
+++ b/law_tools/dashboard/gamma_loop.py
@@ -38,7 +38,12 @@ def compute_gamma_loops(
     gamma_forward = gamma_fn(r_values, y0, phi)
     gamma_reverse = gamma_fn(r_values, y0, -phi)
     loop_area = np.trapz(gamma_forward - gamma_reverse, r_values)
-    return GammaLoopResult(r=r_values, gamma_forward=gamma_forward, gamma_reverse=gamma_reverse, loop_area=float(loop_area))
+    return GammaLoopResult(
+        r=r_values,
+        gamma_forward=gamma_forward,
+        gamma_reverse=gamma_reverse,
+        loop_area=float(loop_area),
+    )
 
 
 def make_gamma_figure(result: GammaLoopResult):  # pragma: no cover - plotting helper

--- a/law_tools/dashboard/main.py
+++ b/law_tools/dashboard/main.py
@@ -1,0 +1,214 @@
+"""CLI entry-point for the RCC dashboard suite."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from ..backend import LawCheckpoint, load_checkpoint
+from ..style import get_theme
+from .echo_playback import build_echo_frames, make_echo_animation
+from .gamma_loop import compute_gamma_loops, make_gamma_figure
+from .neuro_vis import build_neuro_semantic_trace, make_neuro_figure
+from .torsion_map import compute_torsion_map, make_torsion_heatmap
+
+try:  # pragma: no cover - optional dependency boundary
+    from dash import Dash, Input, Output, dcc, html
+except Exception:  # pragma: no cover - fallback when dash not installed
+    Dash = None  # type: ignore
+    Input = Output = None  # type: ignore
+    dcc = html = None  # type: ignore
+
+
+@dataclass
+class DashboardConfig:
+    """Configuration payload for dashboard creation."""
+
+    checkpoint: LawCheckpoint
+    style: str
+    enable_echo: bool
+
+
+DEFAULT_PHI = float(np.pi / 6)
+DEFAULT_Y0 = 0.5
+DEFAULT_CHI = 1.0
+
+
+def _build_layout(app: Dash, config: DashboardConfig):  # pragma: no cover - layout config
+    theme = get_theme(config.style)
+    gamma_result = compute_gamma_loops(DEFAULT_Y0, DEFAULT_PHI)
+    torsion_result = compute_torsion_map(DEFAULT_CHI)
+    law_tokens = config.checkpoint.metadata.get("law_tokens", [])
+    neuro_trace = build_neuro_semantic_trace(law_tokens)
+
+    graphs = [
+        html.Div(
+            [
+                html.H3("γ(r, θ) Law Sculptor"),
+                dcc.Graph(id="gamma-graph", figure=make_gamma_figure(gamma_result)),
+                html.Div(id="gamma-loop-area", children=f"Loop area: {gamma_result.loop_area:.3f}"),
+                dcc.Slider(
+                    id="phi-slider",
+                    min=0.0,
+                    max=float(np.pi / 2),
+                    step=0.01,
+                    value=DEFAULT_PHI,
+                    marks={0: "0", float(np.pi / 2): "π/2"},
+                ),
+                dcc.Slider(
+                    id="y0-slider",
+                    min=0.2,
+                    max=0.8,
+                    step=0.01,
+                    value=DEFAULT_Y0,
+                    marks={0.2: "0.2", 0.8: "0.8"},
+                ),
+                html.Button("Export γ-loop", id="export-gamma", n_clicks=0),
+            ],
+            className="panel",
+        ),
+        html.Div(
+            [
+                html.H3("Torsion Norm Explorer"),
+                dcc.Dropdown(
+                    id="chi-dropdown",
+                    options=[
+                        {"label": f"χ intensity {scale:.1f}", "value": scale}
+                        for scale in (0.5, 1.0, 1.5)
+                    ],
+                    value=DEFAULT_CHI,
+                ),
+                dcc.Checklist(
+                    id="golden-perturb",
+                    options=[{"label": "Enable golden perturbation", "value": "golden"}],
+                    value=[],
+                ),
+                dcc.Graph(
+                    id="torsion-graph",
+                    figure=make_torsion_heatmap(torsion_result),
+                ),
+            ],
+            className="panel",
+        ),
+        html.Div(
+            [
+                html.H3("NeuroSemantic Coupling"),
+                dcc.Graph(id="neuro-graph", figure=make_neuro_figure(neuro_trace)),
+            ],
+            className="panel",
+        ),
+    ]
+
+    if config.enable_echo:
+        echo = build_echo_frames(config.checkpoint.law_tensor)
+        graphs.append(
+            html.Div(
+                [
+                    html.H3("Temporal Echo Playback"),
+                    dcc.Graph(id="echo-graph", figure=make_echo_animation(echo)),
+                ],
+                className="panel",
+            )
+        )
+
+    app.layout = html.Div(
+        graphs,
+        style={
+            "backgroundColor": theme.background,
+            "color": theme.foreground,
+            "padding": "1rem",
+            "fontFamily": "'IBM Plex Sans', sans-serif",
+        },
+    )
+
+
+def _register_callbacks(app: Dash) -> None:  # pragma: no cover - callback wiring
+    @app.callback(
+        Output("gamma-graph", "figure"),
+        Output("gamma-loop-area", "children"),
+        Input("phi-slider", "value"),
+        Input("y0-slider", "value"),
+    )
+    def _update_gamma(phi: float, y0: float):
+        result = compute_gamma_loops(y0, phi)
+        figure = make_gamma_figure(result)
+        summary = f"Loop area: {result.loop_area:.3f}"
+        return figure, summary
+
+    @app.callback(
+        Output("torsion-graph", "figure"),
+        Input("chi-dropdown", "value"),
+        Input("golden-perturb", "value"),
+    )
+    def _update_torsion(chi_value: float, perturb_flags: list[str]):
+        perturb = 0.0
+        if perturb_flags:
+            perturb = 1.0
+        result = compute_torsion_map(chi_value, perturb=perturb)
+        return make_torsion_heatmap(result)
+
+
+def create_dashboard_app(config: DashboardConfig) -> Dash:
+    """Create the Dash app using *config*."""
+
+    if Dash is None:
+        raise RuntimeError(
+            "Dash is not installed. Install 'dash' to launch the dashboard interface."
+        )
+
+    app = Dash(__name__)
+    _build_layout(app, config)
+    _register_callbacks(app)
+    return app
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(description="Launch RCC law dashboards")
+    parser.add_argument("--checkpoint", required=True, help="Path to checkpoint file")
+    parser.add_argument("--port", type=int, default=8052, help="Port to bind server")
+    parser.add_argument("--style", default="QuantumDark", help="Dashboard theme name")
+    parser.add_argument(
+        "--echo-playback", action="store_true", help="Enable temporal echo playback pane"
+    )
+    parser.add_argument(
+        "--enable-live-feed",
+        action="store_true",
+        help="Reserved flag enabling live RCC feed integration",
+    )
+    parser.add_argument("--debug", action="store_true", help="Run server in debug mode")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry-point for running the dashboard from the command line."""
+
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    checkpoint = load_checkpoint(args.checkpoint)
+    config = DashboardConfig(
+        checkpoint=checkpoint,
+        style=args.style,
+        enable_echo=bool(args.echo_playback),
+    )
+
+    if Dash is None:
+        print(
+            "Dash is not installed. Install 'dash' and 'plotly' to run the dashboard.\n"
+            "Loaded checkpoint metadata:"
+        )
+        for key, value in checkpoint.metadata.items():
+            print(f"  - {key}: {value}")
+        return 0
+
+    app = create_dashboard_app(config)
+    app.run_server(host="0.0.0.0", port=args.port, debug=args.debug)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/law_tools/dashboard/neuro_vis.py
+++ b/law_tools/dashboard/neuro_vis.py
@@ -1,0 +1,64 @@
+"""Neuro-semantic coupling visualisations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import numpy as np
+
+try:  # pragma: no cover - optional
+    import plotly.graph_objects as go
+except Exception:  # pragma: no cover
+    go = None
+
+
+@dataclass
+class NeuroSemanticTrace:
+    time: np.ndarray
+    semantic_phase: np.ndarray
+    chi_stream: np.ndarray
+
+
+def build_neuro_semantic_trace(tokens: Iterable[float]) -> NeuroSemanticTrace:
+    """Construct a synthetic semantic drift trace from GPT tokens."""
+
+    tokens_array = np.asarray(list(tokens), dtype=float)
+    if tokens_array.size == 0:
+        tokens_array = np.zeros(1)
+    time = np.linspace(0, tokens_array.size - 1, tokens_array.size)
+    phase = np.unwrap(np.angle(np.exp(1j * tokens_array)))
+    chi_stream = np.gradient(tokens_array)
+    return NeuroSemanticTrace(time=time, semantic_phase=phase, chi_stream=chi_stream)
+
+
+def make_neuro_figure(trace: NeuroSemanticTrace):  # pragma: no cover
+    if go is None:
+        raise RuntimeError("plotly is required for neuro semantic visualisations")
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(x=trace.time, y=trace.semantic_phase, mode="lines", name="∇argΨ"),
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=trace.time,
+            y=trace.chi_stream,
+            mode="lines",
+            name="χ-stream",
+            yaxis="y2",
+        )
+    )
+    fig.update_layout(
+        title="NeuroSemantic Coupling",
+        xaxis_title="Time",
+        yaxis=dict(title="Semantic Phase"),
+        yaxis2=dict(
+            title="χ stream",
+            overlaying="y",
+            side="right",
+        ),
+    )
+    return fig
+
+
+__all__ = ["NeuroSemanticTrace", "build_neuro_semantic_trace", "make_neuro_figure"]

--- a/law_tools/dashboard/torsion_map.py
+++ b/law_tools/dashboard/torsion_map.py
@@ -36,13 +36,14 @@ def make_torsion_heatmap(result: TorsionMapResult, chaos_threshold: float = 0.5)
         raise RuntimeError("plotly is required to generate torsion heatmaps")
 
     fig = go.Figure(
-        data=
-        go.Heatmap(
-            x=result.r[0],
-            y=result.theta[:, 0],
-            z=result.torsion,
-            colorscale="Viridis",
-            colorbar=dict(title="|χ|"),
+        data=(
+            go.Heatmap(
+                x=result.r[0],
+                y=result.theta[:, 0],
+                z=result.torsion,
+                colorscale="Viridis",
+                colorbar=dict(title="|χ|"),
+            )
         )
     )
     fig.update_layout(

--- a/law_tools/dashboard/torsion_map.py
+++ b/law_tools/dashboard/torsion_map.py
@@ -1,0 +1,66 @@
+"""Torsion map rendering helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import plotly.graph_objects as go
+except Exception:  # pragma: no cover
+    go = None
+
+
+@dataclass
+class TorsionMapResult:
+    r: np.ndarray
+    theta: np.ndarray
+    torsion: np.ndarray
+
+
+def compute_torsion_map(chi_int: float, perturb: float = 0.0, size: int = 100) -> TorsionMapResult:
+    """Return torsion norm values across polar coordinates."""
+
+    r = np.linspace(1, 10, size)
+    theta = np.linspace(0, 2 * np.pi, size)
+    R, TH = np.meshgrid(r, theta)
+    golden = (1 + np.sqrt(5.0)) / 2.0
+    base_phase = (2 * np.pi / 3.0) * R + perturb * golden
+    torsion = np.abs(np.sin(base_phase)) * chi_int
+    return TorsionMapResult(r=R, theta=TH, torsion=torsion)
+
+
+def make_torsion_heatmap(result: TorsionMapResult, chaos_threshold: float = 0.5):  # pragma: no cover
+    if go is None:
+        raise RuntimeError("plotly is required to generate torsion heatmaps")
+
+    fig = go.Figure(
+        data=
+        go.Heatmap(
+            x=result.r[0],
+            y=result.theta[:, 0],
+            z=result.torsion,
+            colorscale="Viridis",
+            colorbar=dict(title="|χ|"),
+        )
+    )
+    fig.update_layout(
+        title="Torsion Norm Explorer",
+        xaxis_title="r",
+        yaxis_title="θ",
+        annotations=[
+            dict(
+                text="chaos > 0.5",
+                xref="paper",
+                yref="paper",
+                x=1.02,
+                y=1.05,
+                showarrow=False,
+            )
+        ],
+    )
+    return fig
+
+
+__all__ = ["TorsionMapResult", "compute_torsion_map", "make_torsion_heatmap"]

--- a/law_tools/style/__init__.py
+++ b/law_tools/style/__init__.py
@@ -1,0 +1,5 @@
+"""Styling helpers for law dashboards."""
+
+from .themes import THEMES, Theme, get_theme
+
+__all__ = ["THEMES", "Theme", "get_theme"]

--- a/law_tools/style/themes.py
+++ b/law_tools/style/themes.py
@@ -1,0 +1,55 @@
+"""Dashboard styling utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Theme:
+    name: str
+    background: str
+    foreground: str
+    accent: str
+    grid: str
+
+
+THEMES: Dict[str, Theme] = {
+    "Mandelbrot": Theme(
+        name="Mandelbrot",
+        background="#0b032d",
+        foreground="#f0f3f9",
+        accent="#845ec2",
+        grid="#1f3b4d",
+    ),
+    "Steel": Theme(
+        name="Steel",
+        background="#1c1f26",
+        foreground="#f5f7fa",
+        accent="#5dade2",
+        grid="#2f3640",
+    ),
+    "NeuroDark": Theme(
+        name="NeuroDark",
+        background="#060612",
+        foreground="#e6f4ff",
+        accent="#00f5d4",
+        grid="#232946",
+    ),
+    "QuantumDark": Theme(
+        name="QuantumDark",
+        background="#050913",
+        foreground="#ecf0f1",
+        accent="#9b59b6",
+        grid="#1b1f3a",
+    ),
+}
+
+
+def get_theme(name: str) -> Theme:
+    """Return the requested theme or fall back to ``QuantumDark``."""
+
+    return THEMES.get(name, THEMES["QuantumDark"])
+
+
+__all__ = ["THEMES", "Theme", "get_theme"]


### PR DESCRIPTION
## Summary
- add a new `law_tools` package with backend helpers and dashboard primitives for gamma loops, torsion maps, neuro-semantic traces, and echo playback
- implement a Dash-based dashboard CLI that wires together the new visualisation panes with configurable styling themes
- supply lightweight event bus utilities and theme definitions to support future live RCC integrations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7880049b8832c97961a4ae4eb2218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public get_version() to report the installed package version.
  * Backend: HDF5 checkpoint loader, dataset lister, and extra-field reader; lightweight checkpoint container.
  * Backend: Live event bus and mutable live state for real-time updates.
  * Dashboard: CLI-driven Dash app with gamma loops, torsion heatmaps, neuro-semantic traces, and optional temporal echo playback.
  * Dashboard: Visualization utilities (gamma loop, torsion map, neuro-vis, echo playback) with Plotly-backed figure builders.
  * Style: Theme dataclass, multiple predefined themes, and get_theme helper; package-level re-exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->