### PR TITLE
Enhance chaos visualization and live hook thread safety

### DIFF
--- a/law_tools/backend/live_hooks.py
+++ b/law_tools/backend/live_hooks.py
@@ -1,10 +1,14 @@
 """Asynchronous event hooks bridging the RCC solver and dashboards."""
 from __future__ import annotations
 
+import logging
 import queue
 import threading
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, Optional
+from typing import Callable, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -21,6 +25,7 @@ class LiveHookBus:
     def __init__(self) -> None:
         self._queue: "queue.Queue[LawEvent]" = queue.Queue()
         self._subscribers: list[Callable[[LawEvent], None]] = []
+        self._subscribers_lock = threading.Lock()
         self._stop = threading.Event()
         self._worker: Optional[threading.Thread] = None
 
@@ -28,7 +33,8 @@ class LiveHookBus:
         self._queue.put(event)
 
     def subscribe(self, callback: Callable[[LawEvent], None]) -> None:
-        self._subscribers.append(callback)
+        with self._subscribers_lock:
+            self._subscribers.append(callback)
 
     def start(self) -> None:
         if self._worker and self._worker.is_alive():
@@ -42,8 +48,14 @@ class LiveHookBus:
                     event = self._queue.get(timeout=0.1)
                 except queue.Empty:
                     continue
-                for callback in list(self._subscribers):
-                    callback(event)
+                with self._subscribers_lock:
+                    subscribers_snapshot = list(self._subscribers)
+
+                for callback in subscribers_snapshot:
+                    try:
+                        callback(event)
+                    except Exception:  # pragma: no cover - defensive logging
+                        logger.exception("LiveHookBus callback %r failed", callback)
 
         self._worker = threading.Thread(target=_run, daemon=True)
         self._worker.start()
@@ -59,8 +71,8 @@ class LiveLawState:
     """Mutable container storing the latest law tensor snapshot."""
 
     gamma_trace: list[float] = field(default_factory=list)
-    torsion_noise: float | None = None
-    hysteresis_depth: float | None = None
+    torsion_noise: Optional[float] = None
+    hysteresis_depth: Optional[float] = None
 
     def update_from_tokens(self, tokens: Dict[str, float]) -> None:
         self.gamma_trace.append(tokens.get("LAW_GAMMA_LEVEL", 0.0))

--- a/law_tools/dashboard/torsion_map.py
+++ b/law_tools/dashboard/torsion_map.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 
@@ -32,8 +31,12 @@ def compute_torsion_map(chi_int: float, perturb: float = 0.0, size: int = 100) -
 
 
 def make_torsion_heatmap(result: TorsionMapResult, chaos_threshold: float = 0.5):  # pragma: no cover
+    """Create a heatmap of torsion values with an optional chaos threshold marker."""
+
     if go is None:
         raise RuntimeError("plotly is required to generate torsion heatmaps")
+
+    above_threshold_mask = result.torsion > chaos_threshold
 
     fig = go.Figure(
         data=(
@@ -46,13 +49,25 @@ def make_torsion_heatmap(result: TorsionMapResult, chaos_threshold: float = 0.5)
             )
         )
     )
+
+    if np.any(above_threshold_mask):
+        fig.add_trace(
+            go.Scatter(
+                x=result.r[above_threshold_mask],
+                y=result.theta[above_threshold_mask],
+                mode="markers",
+                marker=dict(color="red", size=5, symbol="x"),
+                name="chaotic region",
+            )
+        )
+
     fig.update_layout(
         title="Torsion Norm Explorer",
         xaxis_title="r",
         yaxis_title="θ",
         annotations=[
             dict(
-                text="chaos > 0.5",
+                text=f"chaos > {chaos_threshold:g}",
                 xref="paper",
                 yref="paper",
                 x=1.02,

--- a/tests/test_live_hooks.py
+++ b/tests/test_live_hooks.py
@@ -1,0 +1,36 @@
+import threading
+
+import pytest
+
+try:
+    from law_tools.backend.live_hooks import LawEvent, LiveHookBus
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    if exc.name == "h5py":
+        pytest.skip("h5py is required to import live hook bus", allow_module_level=True)
+    raise
+
+
+def test_live_hook_bus_handles_callback_errors():
+    bus = LiveHookBus()
+
+    received = []
+    done = threading.Event()
+
+    def failing_callback(event):
+        raise RuntimeError("boom")
+
+    def successful_callback(event):
+        received.append(event.name)
+        done.set()
+
+    bus.subscribe(failing_callback)
+    bus.subscribe(successful_callback)
+
+    bus.start()
+    try:
+        bus.publish(LawEvent(name="update", payload={}))
+        assert done.wait(timeout=1.0)
+    finally:
+        bus.stop()
+
+    assert received == ["update"]

--- a/tests/test_torsion_map.py
+++ b/tests/test_torsion_map.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("plotly.graph_objects", reason="plotly is required for torsion map tests")
+
+from law_tools.dashboard.torsion_map import TorsionMapResult, make_torsion_heatmap
+
+
+def test_make_torsion_heatmap_marks_values_above_threshold():
+    result = TorsionMapResult(
+        r=np.array([[1.0, 2.0], [1.0, 2.0]]),
+        theta=np.array([[0.0, 0.0], [np.pi, np.pi]]),
+        torsion=np.array([[0.4, 0.6], [0.7, 0.3]]),
+    )
+
+    fig = make_torsion_heatmap(result, chaos_threshold=0.5)
+
+    assert fig.data[0].type == "heatmap"
+    assert any(ann.text == "chaos > 0.5" for ann in fig.layout.annotations)
+
+    assert len(fig.data) == 2
+    scatter = fig.data[1]
+    assert scatter.type == "scatter"
+    assert len(scatter.x) == 2
+    assert sorted(scatter.x) == [1.0, 2.0]
+    assert sorted(scatter.y) == pytest.approx([0.0, np.pi])
+
+
+def test_make_torsion_heatmap_without_values_above_threshold():
+    result = TorsionMapResult(
+        r=np.array([[1.0, 2.0], [1.0, 2.0]]),
+        theta=np.array([[0.0, 0.0], [np.pi, np.pi]]),
+        torsion=np.array([[0.2, 0.3], [0.1, 0.2]]),
+    )
+
+    fig = make_torsion_heatmap(result, chaos_threshold=0.5)
+
+    assert len(fig.data) == 1
+    assert any(ann.text == "chaos > 0.5" for ann in fig.layout.annotations)


### PR DESCRIPTION
## Summary
- highlight torsion map chaos threshold by marking high-chaos samples and updating annotations
- make live hook bus thread-safe with subscriber locking and resilient callback handling
- add targeted tests covering torsion heatmap threshold behavior and live hook error resilience

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68e79443a418832c980185051cce6ac3)